### PR TITLE
release: make RPM repo dir structure if it does not exist

### DIFF
--- a/vars/release.groovy
+++ b/vars/release.groovy
@@ -92,7 +92,7 @@ def publishRpmPackages(remote, remotedir, repoName, repoPrefix=null,
             sourceFiles: '*.rpm',
             remoteDirectory: remotedir,
             execCommand: """\
-rm -rf /srv/rpm-repo/${repoName}/packages/*.rpm && \
+rm -rf /srv/rpm-repo/${repoName}/packages/*.rpm && mkdir -p /srv/rpm-repo/${repoName}/packages/ && \
 mv /srv/libelektra/packaging/incoming/${repoName}/*.rpm /srv/rpm-repo/${repoName}/packages/ && \
 createrepo /srv/rpm-repo/${repoName}/ && \
 rm -rf /srv/rpm-repo/${repoName}/repodata/repomd.xml.asc && \


### PR DESCRIPTION
Fixes build errors when adding new Fedora releases.

May I ask for write access?